### PR TITLE
Update CI matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-    name: Python ${{ matrix.python-version }} httpcat test
+    #name: Python ${{ matrix.python-version }} httpcat test
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,5 +12,5 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install .
+    - run: pip install . setuptools wheel
     - run: python setup.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
     name: Python ${{ matrix.python-version }} httpcat test
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-    - run: pip install . setuptools wheel
+    - run: pip install .
     - run: python setup.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
 name: Test
-on: [push]
+on: [push, pull_request]
 jobs:
-  build:
+  test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7]
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+    name: Python ${{ matrix.python-version }} httpcat test
     steps:
-    - uses: actions/checkout@v1
-    - uses: actions/setup-python@v1
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - run: pip install .
     - run: python setup.py test
-    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,6 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
-    #name: Python ${{ matrix.python-version }} httpcat test
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     author=__author__,
     author_email='jakub@roztocil.co',
     license=__licence__,
-    url='https://github.com/jakubroztocil/httpcat',
-    download_url='https://github.com/jakubroztocil/httpcat',
+    url='https://github.com/httpie/httpcat',
+    download_url='https://github.com/httpie/httpcat',
     py_modules=[
         'httpcat',
     ],


### PR DESCRIPTION
3.7 – 3.11 ✅ 
3.12+ will need PEP 517 installer (+Setup 72 removed test entrypoint)